### PR TITLE
Add missing comma in learning page example

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -281,7 +281,7 @@ myDiagram.nodeTemplate =
 
     <pre><code>
 myDiagram.nodeTemplate =
-  $(go.Node, "Vertical" // second argument of a Node/Panel can be a Panel type
+  $(go.Node, "Vertical", // second argument of a Node/Panel can be a Panel type
     /* set Node properties here */
     { // the Node.location point will be at the center of each node
       locationSpot: go.Spot.Center


### PR DESCRIPTION
The lack of this comma would result in an "Uncaught SyntaxError: missing ) after argument list"