### PR TITLE
Fixed doXor and doXnor

### DIFF
--- a/samples/logicCircuit.html
+++ b/samples/logicCircuit.html
@@ -307,13 +307,13 @@
     function doXor(node) {
       var truecount = 0;
       node.findLinksInto().each(function(link) { if (linkIsTrue(link)) truecount++; });
-      var color = truecount % 2 === 0 ? green : red;
+      var color = truecount % 2 !== 0 ? green : red;
       setOutputLinks(node, color);
     }
     function doXnor(node) {
       var truecount = 0;
       node.findLinksInto().each(function(link) { if (linkIsTrue(link)) truecount++; });
-      var color = truecount % 2 !== 0 ? green : red;
+      var color = truecount % 2 === 0 ? green : red;
       setOutputLinks(node, color);
     }
 


### PR DESCRIPTION
The logic for these two gates was backwards. An Xor gate should be a 1 when either input is a 1, and 0 otherwise. Thus, it should be "green" when the truecount is 1, and "red" when truecount is 0 or 2. An XNor gate is the opposite of Xor (obviously).