### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/extensions/CurvedLinkReshaping.html
+++ b/extensions/CurvedLinkReshaping.html
@@ -76,7 +76,7 @@
       if (myDiagram.isModified) {
         if (idx < 0) document.title += "*";
       } else {
-        if (idx >= 0) document.title = document.title.substr(0, idx);
+        if (idx >= 0) document.title = document.title.slice(0, idx);
       }
     });
 

--- a/extensions/LinkLabelDragging.html
+++ b/extensions/LinkLabelDragging.html
@@ -78,7 +78,7 @@
       if (myDiagram.isModified) {
         if (idx < 0) document.title += "*";
       } else {
-        if (idx >= 0) document.title = document.title.substr(0, idx);
+        if (idx >= 0) document.title = document.title.slice(0, idx);
       }
     });
 

--- a/extensions/NodeLabelDragging.html
+++ b/extensions/NodeLabelDragging.html
@@ -78,7 +78,7 @@
       if (myDiagram.isModified) {
         if (idx < 0) document.title += "*";
       } else {
-        if (idx >= 0) document.title = document.title.substr(0, idx);
+        if (idx >= 0) document.title = document.title.slice(0, idx);
       }
     });
 

--- a/extensions/PortShifting.html
+++ b/extensions/PortShifting.html
@@ -78,7 +78,7 @@
       if (myDiagram.isModified) {
         if (idx < 0) document.title += "*";
       } else {
-        if (idx >= 0) document.title = document.title.substr(0, idx);
+        if (idx >= 0) document.title = document.title.slice(0, idx);
       }
     });
 

--- a/extensions/SnapLinkReshaping.html
+++ b/extensions/SnapLinkReshaping.html
@@ -84,7 +84,7 @@
       if (myDiagram.isModified) {
         if (idx < 0) document.title += "*";
       } else {
-        if (idx >= 0) document.title = document.title.substr(0, idx);
+        if (idx >= 0) document.title = document.title.slice(0, idx);
       }
     });
 

--- a/extensionsJSM/CurvedLinkReshaping.html
+++ b/extensionsJSM/CurvedLinkReshaping.html
@@ -123,7 +123,7 @@
         }
         else {
             if (idx >= 0)
-                document.title = document.title.substr(0, idx);
+                document.title = document.title.slice(0, idx);
         }
     });
     // define the Node template

--- a/extensionsJSM/LinkLabelDragging.html
+++ b/extensionsJSM/LinkLabelDragging.html
@@ -124,7 +124,7 @@
       if (myDiagram.isModified) {
         if (idx < 0) document.title += '*';
       } else {
-        if (idx >= 0) document.title = document.title.substr(0, idx);
+        if (idx >= 0) document.title = document.title.slice(0, idx);
       }
     });
 

--- a/extensionsJSM/NodeLabelDragging.html
+++ b/extensionsJSM/NodeLabelDragging.html
@@ -123,7 +123,7 @@
         }
         else {
             if (idx >= 0)
-                document.title = document.title.substr(0, idx);
+                document.title = document.title.slice(0, idx);
         }
     });
 

--- a/extensionsJSM/PortShifting.html
+++ b/extensionsJSM/PortShifting.html
@@ -135,7 +135,7 @@
       }
       else {
         if (idx >= 0)
-          document.title = document.title.substr(0, idx);
+          document.title = document.title.slice(0, idx);
       }
     });
     const palette = new go.Palette('palette'); // create a new Palette in the HTML DIV element "palette"

--- a/extensionsJSM/SnapLinkReshaping.html
+++ b/extensionsJSM/SnapLinkReshaping.html
@@ -135,7 +135,7 @@
       }
       else {
         if (idx >= 0)
-          document.title = document.title.substr(0, idx);
+          document.title = document.title.slice(0, idx);
       }
     });
     // Define a function for creating a "port" that is normally transparent.

--- a/extensionsTS/CurvedLinkReshapingScript.js
+++ b/extensionsTS/CurvedLinkReshapingScript.js
@@ -50,7 +50,7 @@
             }
             else {
                 if (idx >= 0)
-                    document.title = document.title.substr(0, idx);
+                    document.title = document.title.slice(0, idx);
             }
         });
         // define the Node template

--- a/extensionsTS/CurvedLinkReshapingScript.ts
+++ b/extensionsTS/CurvedLinkReshapingScript.ts
@@ -40,7 +40,7 @@ export function init() {
     if (myDiagram.isModified) {
       if (idx < 0) document.title += '*';
     } else {
-      if (idx >= 0) document.title = document.title.substr(0, idx);
+      if (idx >= 0) document.title = document.title.slice(0, idx);
     }
   });
 

--- a/extensionsTS/LinkLabelDraggingScript.js
+++ b/extensionsTS/LinkLabelDraggingScript.js
@@ -51,7 +51,7 @@
             }
             else {
                 if (idx >= 0)
-                    document.title = document.title.substr(0, idx);
+                    document.title = document.title.slice(0, idx);
             }
         });
         // define the Node template

--- a/extensionsTS/LinkLabelDraggingScript.ts
+++ b/extensionsTS/LinkLabelDraggingScript.ts
@@ -42,7 +42,7 @@ export function init() {
     if (myDiagram.isModified) {
       if (idx < 0) document.title += '*';
     } else {
-      if (idx >= 0) document.title = document.title.substr(0, idx);
+      if (idx >= 0) document.title = document.title.slice(0, idx);
     }
   });
 

--- a/extensionsTS/NodeLabelDraggingScript.js
+++ b/extensionsTS/NodeLabelDraggingScript.js
@@ -51,7 +51,7 @@
             }
             else {
                 if (idx >= 0)
-                    document.title = document.title.substr(0, idx);
+                    document.title = document.title.slice(0, idx);
             }
         });
         // define the Node template

--- a/extensionsTS/NodeLabelDraggingScript.ts
+++ b/extensionsTS/NodeLabelDraggingScript.ts
@@ -42,7 +42,7 @@ export function init() {
     if (myDiagram.isModified) {
       if (idx < 0) document.title += '*';
     } else {
-      if (idx >= 0) document.title = document.title.substr(0, idx);
+      if (idx >= 0) document.title = document.title.slice(0, idx);
     }
   });
 

--- a/extensionsTS/PortShiftingScript.js
+++ b/extensionsTS/PortShiftingScript.js
@@ -50,7 +50,7 @@
             }
             else {
                 if (idx >= 0)
-                    document.title = document.title.substr(0, idx);
+                    document.title = document.title.slice(0, idx);
             }
         });
         var palette = new go.Palette('palette'); // create a new Palette in the HTML DIV element "palette"

--- a/extensionsTS/PortShiftingScript.ts
+++ b/extensionsTS/PortShiftingScript.ts
@@ -42,7 +42,7 @@ export function init() {
     if (myDiagram.isModified) {
       if (idx < 0) document.title += '*';
     } else {
-      if (idx >= 0) document.title = document.title.substr(0, idx);
+      if (idx >= 0) document.title = document.title.slice(0, idx);
     }
   });
 

--- a/extensionsTS/SnapLinkReshapingScript.js
+++ b/extensionsTS/SnapLinkReshapingScript.js
@@ -55,7 +55,7 @@
             }
             else {
                 if (idx >= 0)
-                    document.title = document.title.substr(0, idx);
+                    document.title = document.title.slice(0, idx);
             }
         });
         // Define a function for creating a "port" that is normally transparent.

--- a/extensionsTS/SnapLinkReshapingScript.ts
+++ b/extensionsTS/SnapLinkReshapingScript.ts
@@ -49,7 +49,7 @@ export function init() {
     if (myDiagram.isModified) {
       if (idx < 0) document.title += '*';
     } else {
-      if (idx >= 0) document.title = document.title.substr(0, idx);
+      if (idx >= 0) document.title = document.title.slice(0, idx);
     }
   });
 

--- a/projects/bpmn/BPMNScript.js
+++ b/projects/bpmn/BPMNScript.js
@@ -857,7 +857,7 @@ var __extends = (this && this.__extends) || (function () {
             }
             else {
                 if (idx >= 0)
-                    currentFile.textContent = currentFile.textContent.substr(0, idx);
+                    currentFile.textContent = currentFile.textContent.slice(0, idx);
             }
         });
         // ------------------------------------------  Palette   ----------------------------------------------
@@ -1266,7 +1266,7 @@ var __extends = (this && this.__extends) || (function () {
         var currentFile = document.getElementById('currentFile');
         var name = currentFile.textContent || '';
         if (name && name[name.length - 1] === '*')
-            return name.substr(0, name.length - 1);
+            return name.slice(0, -1);
         return name;
     }
     exports.getCurrentFileName = getCurrentFileName;

--- a/projects/bpmn/BPMNScript.ts
+++ b/projects/bpmn/BPMNScript.ts
@@ -1228,7 +1228,7 @@ export function init() {
     if (myDiagram.isModified) {
       if (idx < 0) currentFile.textContent = currentFile.textContent + '*';
     } else {
-      if (idx >= 0) currentFile.textContent = currentFile.textContent!.substr(0, idx);
+      if (idx >= 0) currentFile.textContent = currentFile.textContent!.slice(0, idx);
     }
   });
 
@@ -1654,7 +1654,7 @@ const UnsavedFileName = '(Unsaved File)';
 export function getCurrentFileName(): string {
   const currentFile = document.getElementById('currentFile') as HTMLDivElement;
   const name = currentFile.textContent || '';
-  if (name && name[name.length - 1] === '*') return name.substr(0, name.length - 1);
+  if (name && name[name.length - 1] === '*') return name.slice(0, -1);
   return name;
 }
 

--- a/projects/floorplanner/Floorplan.js
+++ b/projects/floorplanner/Floorplan.js
@@ -90,7 +90,7 @@ function Floorplan(div) {
                     if (idx < 0) currentFile.textContent = currentFile.textContent + "*";
                 }
                 else {
-                    if (idx >= 0) currentFile.textContent = currentFile.textContent.substr(0, idx);
+                    if (idx >= 0) currentFile.textContent = currentFile.textContent.slice(0, idx);
                 }
             }
         }

--- a/projects/floorplanner/FloorplanFilesystem.js
+++ b/projects/floorplanner/FloorplanFilesystem.js
@@ -252,7 +252,7 @@ FloorplanFilesystem.prototype.getCurrentFileName = function () {
     var currentFile = document.getElementById(this.state.currentFileId);
     if (currentFile) {
         var name = currentFile.textContent;
-        if (name[name.length - 1] === "*") return name.substr(0, name.length - 1);
+        if (name[name.length - 1] === "*") return name.slice(0, -1);
     }
     return name;
 }

--- a/projects/floorplannerTS/src/EditorHelper.js
+++ b/projects/floorplannerTS/src/EditorHelper.js
@@ -56,7 +56,7 @@
                         }
                         else {
                             if (idx >= 0)
-                                currentFile.textContent = currentFile.textContent.substr(0, idx);
+                                currentFile.textContent = currentFile.textContent.slice(0, idx);
                         }
                     }
                 });
@@ -105,7 +105,7 @@
                 var currentFile = document.getElementById('ge-filename');
                 var currentFileTitle = currentFile.innerText;
                 if (currentFileTitle[currentFileTitle.length - 1] === '*' && editorHelper.storageManager.currentStorage.currentDiagramFile.name != null) {
-                    currentFile.innerText = currentFileTitle.substr(0, currentFileTitle.length - 1);
+                    currentFile.innerText = currentFileTitle.slice(0, -1);
                     editorHelper.storageManager.currentStorage.save();
                 }
             });
@@ -310,7 +310,7 @@
                     var currentFile = document.getElementById('ge-filename');
                     // only prompt to save current changes iff there is some modified state
                     var currentFileTitle = currentFile.innerText;
-                    if (currentFileTitle.substr(currentFileTitle.length - 1, 1) === '*') {
+                    if (currentFileTitle.slice(-1) === '*') {
                         saveBefore = true;
                     }
                     editorHelper.storageManager.create(saveBefore).then(function (fileData) {

--- a/projects/floorplannerTS/src/EditorHelper.ts
+++ b/projects/floorplannerTS/src/EditorHelper.ts
@@ -67,7 +67,7 @@ export class EditorHelper {
           if (e.diagram.isModified) {
             if (idx < 0) currentFile.textContent = currentFile.textContent + '*';
           } else {
-            if (idx >= 0) currentFile.textContent = (currentFile.textContent as string).substr(0, idx);
+            if (idx >= 0) currentFile.textContent = (currentFile.textContent as string).slice(0, idx);
           }
         }
       });
@@ -126,7 +126,7 @@ export class EditorHelper {
       const currentFile = document.getElementById('ge-filename') as HTMLElement;
       const currentFileTitle = currentFile.innerText;
       if (currentFileTitle[currentFileTitle.length - 1] === '*' && editorHelper.storageManager.currentStorage.currentDiagramFile.name != null) {
-        currentFile.innerText = currentFileTitle.substr(0, currentFileTitle.length - 1);
+        currentFile.innerText = currentFileTitle.slice(0, -1);
         editorHelper.storageManager.currentStorage.save();
       }
     });
@@ -318,7 +318,7 @@ export class EditorHelper {
         const currentFile = document.getElementById('ge-filename');
         // only prompt to save current changes iff there is some modified state
         const currentFileTitle = (currentFile as HTMLElement).innerText;
-        if (currentFileTitle.substr(currentFileTitle.length - 1, 1) === '*') {
+        if (currentFileTitle.slice(-1) === '*') {
           saveBefore = true;
         }
         editorHelper.storageManager.create(saveBefore).then(function(fileData: any) {

--- a/projects/pdf/blob-stream.js
+++ b/projects/pdf/blob-stream.js
@@ -478,7 +478,7 @@ function hexWrite (buf, string, offset, length) {
     length = strLen / 2
   }
   for (var i = 0; i < length; i++) {
-    var byte = parseInt(string.substr(i * 2, 2), 16)
+    var byte = parseInt(string.slice(i * 2, i * 2 + 2), 16)
     if (isNaN(byte)) throw new Error('Invalid hex string')
     buf[offset + i] = byte
   }
@@ -1153,7 +1153,7 @@ function utf8ToBytes (str) {
     } else {
       var start = i
       if (b >= 0xD800 && b <= 0xDFFF) i++
-      var h = encodeURIComponent(str.slice(start, i+1)).substr(1).split('%')
+      var h = encodeURIComponent(str.slice(start, i+1)).slice(1).split('%')
       for (var j = 0; j < h.length; j++) {
         byteArray.push(parseInt(h[j], 16))
       }
@@ -4487,7 +4487,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
         if (array) {
           str = str.split('\n').map(function(line) {
             return '  ' + line;
-          }).join('\n').substr(2);
+          }).join('\n').slice(2);
         } else {
           str = '\n' + str.split('\n').map(function(line) {
             return '   ' + line;
@@ -4504,7 +4504,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     }
     name = JSON.stringify('' + key);
     if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
-      name = name.substr(1, name.length - 2);
+      name = name.slice(1, -1);
       name = ctx.stylize(name, 'name');
     } else {
       name = name.replace(/'/g, "\\'")

--- a/projects/pdf/pdfkit.js
+++ b/projects/pdf/pdfkit.js
@@ -6506,7 +6506,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
         if (array) {
           str = str.split('\n').map(function(line) {
             return '  ' + line;
-          }).join('\n').substr(2);
+          }).join('\n').slice(2);
         } else {
           str = '\n' + str.split('\n').map(function(line) {
             return '   ' + line;
@@ -6523,7 +6523,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     }
     name = JSON.stringify('' + key);
     if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
-      name = name.substr(1, name.length - 2);
+      name = name.slice(1, -1);
       name = ctx.stylize(name, 'name');
     } else {
       name = name.replace(/'/g, "\\'")
@@ -16505,7 +16505,7 @@ function hexWrite (buf, string, offset, length) {
     length = strLen / 2
   }
   for (var i = 0; i < length; ++i) {
-    var parsed = parseInt(string.substr(i * 2, 2), 16)
+    var parsed = parseInt(string.slice(i * 2, i * 2 + 2), 16)
     if (numberIsNaN(parsed)) return i
     buf[offset + i] = parsed
   }
@@ -21177,7 +21177,7 @@ function objectToString(o) {
 	            // Convert
 	            var words = [];
 	            for (var i = 0; i < hexStrLength; i += 2) {
-	                words[i >>> 3] |= parseInt(hexStr.substr(i, 2), 16) << (24 - (i % 8) * 4);
+	                words[i >>> 3] |= parseInt(hexStr.slice(i, i + 2), 16) << (24 - (i % 8) * 4);
 	            }
 
 	            return new WordArray.init(words, hexStrLength / 2);

--- a/projects/storage/GoDropBox.js
+++ b/projects/storage/GoDropBox.js
@@ -216,7 +216,7 @@ var __extends = (this && this.__extends) || (function () {
               console.log("got authTokenRevoke error:");
               console.log(error);
             });*/
-            // window.location.href = window.location.href.substr(0, window.location.href.indexOf('#'));
+            // window.location.href = window.location.href.substring(0, window.location.href.indexOf('#'));
         };
         /*
         No longer used???

--- a/projects/storage/GoDropBox.ts
+++ b/projects/storage/GoDropBox.ts
@@ -198,7 +198,7 @@ export class GoDropBox extends gcs.GoCloudStorage {
           console.log("got authTokenRevoke error:");
           console.log(error);
         });*/
-        // window.location.href = window.location.href.substr(0, window.location.href.indexOf('#'));
+        // window.location.href = window.location.href.substring(0, window.location.href.indexOf('#'));
     }
 
     /*

--- a/samples/IVRtree.html
+++ b/samples/IVRtree.html
@@ -77,7 +77,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/dataFlow.html
+++ b/samples/dataFlow.html
@@ -76,7 +76,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/dataFlowVertical.html
+++ b/samples/dataFlowVertical.html
@@ -76,7 +76,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/draggableLink.html
+++ b/samples/draggableLink.html
@@ -94,7 +94,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/dynamicPorts.html
+++ b/samples/dynamicPorts.html
@@ -69,7 +69,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/faultTree.html
+++ b/samples/faultTree.html
@@ -77,7 +77,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/flowBuilder.html
+++ b/samples/flowBuilder.html
@@ -80,7 +80,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/flowchart.html
+++ b/samples/flowchart.html
@@ -74,7 +74,7 @@
       if (myDiagram.isModified) {
         if (idx < 0) document.title += "*";
       } else {
-        if (idx >= 0) document.title = document.title.substr(0, idx);
+        if (idx >= 0) document.title = document.title.slice(0, idx);
       }
     });
 

--- a/samples/grafcet.html
+++ b/samples/grafcet.html
@@ -76,7 +76,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/linksToLinks.html
+++ b/samples/linksToLinks.html
@@ -73,7 +73,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/logicCircuit.html
+++ b/samples/logicCircuit.html
@@ -77,7 +77,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/mindMap.html
+++ b/samples/mindMap.html
@@ -76,7 +76,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 
@@ -254,7 +254,7 @@
       if (idx < 0) {
         tb.font = "bold " + tb.font;
       } else {
-        tb.font = tb.font.substr(idx + 5);
+        tb.font = tb.font.slice(idx + 5);
       }
       adorn.diagram.commitTransaction("Change Text Weight");
     }

--- a/samples/network.html
+++ b/samples/network.html
@@ -73,7 +73,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/orgChartAssistants.html
+++ b/samples/orgChartAssistants.html
@@ -106,7 +106,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/orgChartEditor.html
+++ b/samples/orgChartEditor.html
@@ -105,7 +105,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/orgChartExtras.html
+++ b/samples/orgChartExtras.html
@@ -99,7 +99,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/pageFlow.html
+++ b/samples/pageFlow.html
@@ -96,7 +96,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/pipes.html
+++ b/samples/pipes.html
@@ -97,7 +97,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/processFlow.html
+++ b/samples/processFlow.html
@@ -78,7 +78,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/regroupingTreeView.html
+++ b/samples/regroupingTreeView.html
@@ -89,7 +89,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/sankey.html
+++ b/samples/sankey.html
@@ -218,7 +218,7 @@
         var nodedata = myDiagram.model.findNodeDataForKey(data.from);
         var hex = nodedata.color;
         if (hex.charAt(0) == '#') {
-          var rgb = parseInt(hex.substr(1, 6), 16);
+          var rgb = parseInt(hex.slice(1, 7), 16);
           var r = rgb >> 16;
           var g = rgb >> 8 & 0xFF;
           var b = rgb & 0xFF;

--- a/samples/sequenceDiagram.html
+++ b/samples/sequenceDiagram.html
@@ -81,7 +81,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/sequentialFunction.html
+++ b/samples/sequentialFunction.html
@@ -72,7 +72,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/stateChart.html
+++ b/samples/stateChart.html
@@ -94,7 +94,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/stateChartIncremental.html
+++ b/samples/stateChartIncremental.html
@@ -83,7 +83,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samples/systemDynamics.html
+++ b/samples/systemDynamics.html
@@ -124,7 +124,7 @@
         if (myDiagram.isModified) {
           if (idx < 0) document.title += "*";
         } else {
-          if (idx >= 0) document.title = document.title.substr(0, idx);
+          if (idx >= 0) document.title = document.title.slice(0, idx);
         }
       });
 

--- a/samplesTS/flowchart.js
+++ b/samplesTS/flowchart.js
@@ -39,7 +39,7 @@
             }
             else {
                 if (idx >= 0)
-                    document.title = document.title.substr(0, idx);
+                    document.title = document.title.slice(0, idx);
             }
         });
         // helper definitions for node templates

--- a/samplesTS/flowchart.ts
+++ b/samplesTS/flowchart.ts
@@ -28,7 +28,7 @@ export function init() {
     if (myDiagram.isModified) {
       if (idx < 0) document.title += '*';
     } else {
-      if (idx >= 0) document.title = document.title.substr(0, idx);
+      if (idx >= 0) document.title = document.title.slice(0, idx);
     }
   });
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.