### PR TITLE
fix typo code snippet

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -427,7 +427,7 @@ myDiagram.nodeTemplate =
           // or when the image is partially transparent.
           { margin: 10, width: 50, height: 50, background: "red" })
         // Picture.source is data bound to the "source" attribute of the model data
-        .bind("source")),
+        .bind("source"),
       new go.TextBlock("Default Text",  // the initial value for TextBlock.text
           // some room around the text, a larger font, and a white stroke:
           { margin: 12, stroke: "white", font: "bold 16px sans-serif" })


### PR DESCRIPTION
Good afternoon,

I noticed a typo in a code snippet in the index.html of the learn module. This caused a syntax error when executing the code snippet. 


Kind regards,

Mikkel
