### PR TITLE
fix typos in intro links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ projects/minimalSource/minimal.js
 projects/maximalSource/maximal.js
 projects/minimalSourceBrowserify/minimal.js
 !projects/*/src
+.idea

--- a/intro/HTMLInteraction.html
+++ b/intro/HTMLInteraction.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/SVGContext.html
+++ b/intro/SVGContext.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/angular.html
+++ b/intro/angular.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/animation.html
+++ b/intro/animation.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/brush.html
+++ b/intro/brush.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/buildingObjects.html
+++ b/intro/buildingObjects.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/buttons.html
+++ b/intro/buttons.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/changedEvents.html
+++ b/intro/changedEvents.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/collections.html
+++ b/intro/collections.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/commands.html
+++ b/intro/commands.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/connectionPoints.html
+++ b/intro/connectionPoints.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/contextMenus.html
+++ b/intro/contextMenus.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/dataBinding.html
+++ b/intro/dataBinding.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/debugging.html
+++ b/intro/debugging.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/deployment.html
+++ b/intro/deployment.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/events.html
+++ b/intro/events.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/extensions.html
+++ b/intro/extensions.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/geometry.html
+++ b/intro/geometry.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/graduatedPanels.html
+++ b/intro/graduatedPanels.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/grids.html
+++ b/intro/grids.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/groups.html
+++ b/intro/groups.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/highlighting.html
+++ b/intro/highlighting.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/index.html
+++ b/intro/index.html
@@ -190,8 +190,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -209,7 +209,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/initialView.html
+++ b/intro/initialView.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/itemArrays.html
+++ b/intro/itemArrays.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/layers.html
+++ b/intro/layers.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/layouts.html
+++ b/intro/layouts.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/legends.html
+++ b/intro/legends.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/linkLabels.html
+++ b/intro/linkLabels.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/links.html
+++ b/intro/links.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/makingImages.html
+++ b/intro/makingImages.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/makingSVG.html
+++ b/intro/makingSVG.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/nodeScript.html
+++ b/intro/nodeScript.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/nodes.html
+++ b/intro/nodes.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/overview.html
+++ b/intro/overview.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/palette.html
+++ b/intro/palette.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/panels.html
+++ b/intro/panels.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/performance.html
+++ b/intro/performance.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/permissions.html
+++ b/intro/permissions.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/pictures.html
+++ b/intro/pictures.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/platforms.html
+++ b/intro/platforms.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/ports.html
+++ b/intro/ports.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/printing.html
+++ b/intro/printing.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/react.html
+++ b/intro/react.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/replacingDeleting.html
+++ b/intro/replacingDeleting.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/resizing.html
+++ b/intro/resizing.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/routers.html
+++ b/intro/routers.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/selection.html
+++ b/intro/selection.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/serverSideImages.html
+++ b/intro/serverSideImages.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/shapes.html
+++ b/intro/shapes.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/sizedGroups.html
+++ b/intro/sizedGroups.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/sizing.html
+++ b/intro/sizing.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/source.html
+++ b/intro/source.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/subgraphs.html
+++ b/intro/subgraphs.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/subtrees.html
+++ b/intro/subtrees.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/svelte.html
+++ b/intro/svelte.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/tablePanels.html
+++ b/intro/tablePanels.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/templateMaps.html
+++ b/intro/templateMaps.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/testing.html
+++ b/intro/testing.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/textBlocks.html
+++ b/intro/textBlocks.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/theming.html
+++ b/intro/theming.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>
@@ -763,19 +763,19 @@ changeTheme6 = () => {
         <h2 class="text-base font-semibold text-nwoods-primary">Company</h2>
         <ul class="list-none space-y-4 md:space-y-1 px-0">
           <li>
-            <a target="_blank" href="https://nwoods.com" target="_blank" rel="noopener">Northwoods</a>
+            <a href="https://nwoods.com" target="_blank" rel="noopener">Northwoods</a>
           </li>
           <li>
-            <a target="_blank" href="https://nwoods.com/about.html" target="_blank" rel="noopener">About Us</a>
+            <a href="https://nwoods.com/about.html" target="_blank" rel="noopener">About Us</a>
           </li>
           <li>
-            <a target="_blank" href="https://nwoods.com/contact.html" target="_blank" rel="noopener">Contact Us</a>
+            <a href="https://nwoods.com/contact.html" target="_blank" rel="noopener">Contact Us</a>
           </li>
           <li>
-            <a target="_blank" href="https://nwoods.com/consulting.html" target="_blank" rel="noopener">Consulting</a>
+            <a href="https://nwoods.com/consulting.html" target="_blank" rel="noopener">Consulting</a>
           </li>
           <li>
-            <a target="_blank" href="https://twitter.com/northwoodsgo" target="_blank" rel="noopener">Twitter</a>
+            <a href="https://twitter.com/northwoodsgo" target="_blank" rel="noopener">Twitter</a>
           </li>
         </ul>
       </div>

--- a/intro/tools.html
+++ b/intro/tools.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/tooltips.html
+++ b/intro/tooltips.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/transactions.html
+++ b/intro/transactions.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/trees.html
+++ b/intro/trees.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/typings.html
+++ b/intro/typings.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/usingModels.html
+++ b/intro/usingModels.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/validation.html
+++ b/intro/validation.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>

--- a/intro/viewport.html
+++ b/intro/viewport.html
@@ -185,8 +185,8 @@
   <a href="theming.html">Theming</a>
   <a href="routers.html">Routers</a>
   <a href="animation.html">Animation</a>
-  <a href="toolTips.html">ToolTips</a>
-  <a href="contextmenus.html">Context Menus</a>
+  <a href="tooltips.html">ToolTips</a>
+  <a href="contextMenus.html">Context Menus</a>
   <a href="events.html">Diagram Events</a>
   <a href="tools.html">Tools</a>
   <a href="commands.html">Commands</a>
@@ -204,7 +204,7 @@
   <a href="geometry.html">Geometry Strings</a>
   <a href="grids.html">Grid Patterns</a>
   <a href="graduatedPanels.html">Graduated Panels</a>
-  <a href="SVGcontext.html">Rendering to SVG</a>
+  <a href="SVGContext.html">Rendering to SVG</a>
   <a href="makingSVG.html">Snapshot to SVG</a>
   <a href="makingImages.html">Diagram Images</a>
   <a href="printing.html">Printing</a>


### PR DESCRIPTION
Good morning,

Some links in the 'Intro' section seemed not to be working. This was caused by some typos. With this commit I fixed them.

The links fixed were for:

- ToolTips
- Context Menus
- Rendering to SVG

In the process I removed some duplicate targets in 'theming.html', too.


Kind regards,

MikkelvtK